### PR TITLE
uboot-mkimage: show help before ERROR message

### DIFF
--- a/U-boot/README
+++ b/U-boot/README
@@ -1,0 +1,36 @@
+============================================================
+Title:            README
+
+Author:           Jose Lopez
+
+Date:             2016-10-13
+
+Email address:    joselj@ugr.es
+
+Description:      Brief readme file to use uboot-mkimage.sh
+
+============================================================
+
+To make use of uboot-mkimage.sh, you will need a copy of the ugr-scripts
+repository which is available at https://github.com/TimingKeepers/ugr-scripts
+
+The script can be found at <repo_directory>/U-boot/uboot-mkimage.sh
+
+
+First of all, you will need to export an environment variable:
+
+  $ export SCRIPT_BASE_FOLDER=/absolute/path/to/repository/ugr-scripts
+
+
+Then, if you have a uramimage.image.gz file and you want to unpack it to some
+location, just run:
+
+  $ ./uboot-mkimage.sh -u -r /absolute/path/where/image/will/be/unpacked -i /absolute/path/to/uramdisk.image.gz
+
+
+Or the other way around (packing rootfs to a file):
+
+  $ ./uboot-mkimage.sh -p -r /absolute/path/where/image/will/be/unpacked -i /absolute/path/to/uramdisk.image.gz
+
+
+Easy!

--- a/U-boot/uboot-mkimage.sh
+++ b/U-boot/uboot-mkimage.sh
@@ -9,7 +9,29 @@
 #
 
 #include util.sh
+
+function help_msg {
+	echo -e  "-------------------------------------------------------------------"
+	echo -e  "$(basename $0) -p -u -r <rootfs> -i <image>"
+	echo -e  ""
+	echo -e  "Options:"
+	echo -e  "\t-m: Mode (pack|unpack)"
+	echo -e  "\t-c: Compress mode (none|gzip)"
+	echo -e  "\t-r: Root filesystem folder"
+	echo -e  "\t-i: Image name without extension"
+	echo -e  "\t-h: Print help message"
+	echo -e  ""
+	echo -e  "Variable SCRIPT_BASE_FOLDER must contain repository parent folder"
+	echo -e  ""
+	echo -e  "-------------------------------------------------------------------"
+	echo -e  "Copyright (C) 2015, University of Granada"
+	echo -e  "Miguel Jimenez Lopez <klyone@ugr.es>"
+	echo -e  "GPLv2 License or later"
+	echo -e  "-------------------------------------------------------------------"
+}
+
 if [ -z ${SCRIPT_BASE_FOLDER} ] ; then
+	help_msg
 	echo "ERROR: SCRIPT_BASE_FOLDER var not defined!"
 	exit -1
 fi
@@ -47,24 +69,6 @@ function uboot_image_pack {
 			fail "pack mode invalid: none | gzip"
 			;;
 	esac
-}
-
-function help_msg {
-	echo_norm "-------------------------------------------------------------------"
-	echo_norm "$(basename $0) -p -u -r <rootfs> -i <image>"
-	echo_norm ""
-	echo_norm "Options:"
-	echo_norm "\t-m: Mode (pack|unpack)"
-	echo_norm "\t-c: Compress mode (none|gzip)"
-	echo_norm "\t-r: Root filesystem folder"
-	echo_norm "\t-i: Image name without extension"
-	echo_norm "\t-h: Print help message"
-	echo_norm ""
-	echo_norm "-------------------------------------------------------------------"
-	echo_norm "Copyright (C) 2015, University of Granada"
-	echo_norm "Miguel Jimenez Lopez <klyone@ugr.es>"
-	echo_norm "GPLv2 License or later"
-	echo_norm "-------------------------------------------------------------------"
 }
 
 while getopts ":m:c:r:i:h" opt; do


### PR DESCRIPTION
Buenas, Miguel

Estos son los cambios básicos que he hecho para evitar que _solo_ se muestre el error de la variable de entorno.
Total, en la ayuda no se hace uso alguno de los caracteres de escape, pero he preferido mantener la misma funcionalidad que en la función echo_norm de util.sh.

Ya ves la tontería, pero bueno :)

Saludos,
Jose
